### PR TITLE
Fix use of p-value threshold

### DIFF
--- a/q2_PSEA/actions/psea.py
+++ b/q2_PSEA/actions/psea.py
@@ -69,7 +69,6 @@ def make_psea_table(
 
         titles = []
         taxa_access = "species_name"
-        p_val_thresholds = []
         used_pairs = []
         pair_spline_dict = {}
 
@@ -122,7 +121,6 @@ def make_psea_table(
             )
 
             taxa = table.loc[:, taxa_access].to_list()
-            p_val_thresholds.append(p_val_thresh / len(taxa))
 
             titles.append(prefix)
 
@@ -145,7 +143,7 @@ def make_psea_table(
             pairs_file=f"{tempdir}/used_pairs.tsv",
             spline_file=f"{tempdir}/timepoint_spline_values.tsv",
             highlight_data=table_dir,
-            highlight_thresholds=p_val_thresholds,
+            highlight_thresholds=[p_val_thresh],
             species_taxa_file=species_taxa_file
         )
 
@@ -154,7 +152,7 @@ def make_psea_table(
             xy_access=["NES", "p.adjust"],
             taxa_access=taxa_access,
             x_threshold=es_thresh,
-            y_thresholds=p_val_thresholds,
+            y_thresholds=[p_val_thresh],
             xy_labels=["Enrichment score", "Adjusted p-values"],
             titles=titles
         )

--- a/q2_PSEA/plugin_setup.py
+++ b/q2_PSEA/plugin_setup.py
@@ -51,9 +51,7 @@ plugin.pipelines.register_function(
         "threshold": "Minimum Z score a peptide must maintain to be"
             " considered in Gene Set Enrichment Analysis.",
         "p_val_thresh": "Specifies the value adjusted p-values must meet to be"
-            " considered for highlighting in volcano and scatter plots. If a"
-            " threshold is not provided, then the theshold is set to 0.05 / N"
-            " - where N is the number of taxa being tested.",
+            " considered for highlighting in volcano and scatter plots.",
         "es_thresh": "Specifies the value ",
         "min_size": "Minimum allowed number of peptides from peptide set also"
             " the data set.",
@@ -61,7 +59,7 @@ plugin.pipelines.register_function(
             " the data set.",
         "permutation_num": "Number of permutations. Minimal possible nominal"
             " p-value is about 1/perm.",
-        "spline_type": "",
+        "spline_type": "Specifies which spline operation to use.",
         "table_dir": "Directory where resulting PSEA tables will be stored.",
         "threads": "Number of threads with which to run ssGSEA operation.",
         "pepsirf_binary": "Path to pepsirf binary."


### PR DESCRIPTION
Finally updated how the 'p_val_thresh' parameter is used. Instead of manually adjusting the threshold, the plug-in just takes the threshold provided by the user. This is due to the fact that PSEA already provides a 'p.adjust' column in the result which nullifies the need for any manual adjustment.

Also, added a description for the 'spline_type' parameter.